### PR TITLE
Fix Typo for Bernoulli distribution

### DIFF
--- a/chapters/part2/bernoulli/index.html
+++ b/chapters/part2/bernoulli/index.html
@@ -61,7 +61,7 @@
     \begin{align}
     E[X^2]
     &= \sum_x x^2 \cdot \p(X=x) &&\text{LOTUS}\\
-    &= 0^2 \cdot p + 1^2 \cdot p\\
+    &= 0^2 \cdot (1-p) + 1^2 \cdot p\\
     &= p
     \end{align}
     $$


### PR DESCRIPTION
Probability for 0 in proofing E[X^2] should be 1 - p not p.