### PR TITLE
Update index.html

### DIFF
--- a/chapters/part1/bayes_theorem/index.html
+++ b/chapters/part1/bayes_theorem/index.html
@@ -122,7 +122,7 @@ $$
 \begin{align}
 \p(B_i | E) &= \frac{\p(E|B_i) \cdot \p(B_i)}{\p(E)}
 && \text{Bayes Theorem. What to do about $\p(E)$?} \\
- &= \frac{\p(E|B_i) \cdot \p(B_i)}{\sum_{i=1}^n \p(E|B_i) \cdot \p(B_i)}
+ &= \frac{\p(E|B_i) \cdot \p(B_i)}{\sum_{j=1}^n \p(E|B_j) \cdot \p(B_j)}
 && \text{Use General Law of Total Probability for $\p(E)$} \\
 \end{align}
 $$


### PR DESCRIPTION
Hey! For Bayes theorem, part 3: Bayes with the General Law of Probability, shouldn't the last equations denominator use j = 1, instead of i (This is what I changed). 
Since i is used in the Bayes equations numerator and this makes it seem that the Sum notation of the denominator is also dependent of the changing i's.