### PR TITLE
Update Exponential Distribution Graph Axes

### DIFF
--- a/templates/rvCards/exponential.html
+++ b/templates/rvCards/exponential.html
@@ -85,7 +85,7 @@ function drawExponentialPdf(parentDivId, lambda) {
 		}
 	}
 	let xLabel = 'Values that X can take on'
-	let yLabel = 'Probability'
+	let yLabel = 'Probability Density'
 
 	var config = standardPDFConfig(xValues, yValues, xLabel, yLabel)
 	var ctx = document.getElementById(parentDivId).getContext('2d');


### PR DESCRIPTION
The y-axis label for the graph in the Exponential Distribution card should say Probability Density instead of Probability.