### PR TITLE
Fix UnicodeDecodeError by specifying UTF-8 encoding when opening files

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -36,18 +36,15 @@ class Compiler(object):
     #####################
 
     def compileTemplate(self, relativePath):
-        # print(relativePath)
         pathToLangRoot = self.getPathToRoot(relativePath)
         filePath = os.path.join(TEMPLATE_DIR, relativePath)
-        templateText = open(filePath).read()
+        templateText = open(filePath, encoding='utf-8').read()
         params = {
             'pathToRoot': '../' + pathToLangRoot, 
             'pathToLang' : pathToLangRoot,
         }
         self.addChapterLinks(params)
         compiledHtml = SimpleTemplate(templateText).render(params)
-        
-        fileName, fileExtension = os.path.splitext(relativePath)
         compiledHtml = compiledHtml.encode('utf8')
         path = OUT_DIR + '/' + relativePath
         self.makePath(path)


### PR DESCRIPTION
### Fix UnicodeDecodeError by specifying UTF-8 encoding when opening files

#### Description
This pull request addresses the `UnicodeDecodeError` encountered on Windows 11 when reading files with the default system encoding (cp1252). By specifying UTF-8 encoding explicitly, we ensure that the file can be read correctly, preventing the decode error.

Besides these issue, i've removed unnecessary comments and lines from the method

#### Changes Made
- Updated `compileTemplate` method in `compile.py` to specify `encoding='utf-8'` when opening files.

#### Tests
Tested locally and verified that the error is resolved.
