### PR TITLE
Part 1: "Probability of or": Corrected inclusion-exclusion formula

### DIFF
--- a/chapters/part1/prob_or/index.html
+++ b/chapters/part1/prob_or/index.html
@@ -148,7 +148,7 @@ $$
 
 $$
 \begin{gather}
-\P(E_1 \or E_2 \or \cdots \or E_n) = \sum\limits_{r-1}^n (-1)^{r+1} Y_r \\
+\P(E_1 \or E_2 \or \cdots \or E_n) = \sum\limits_{r=1}^n (-1)^{r+1} Y_r \\
 \text{s.t. } Y_r = \sum\limits_{1 \leq i_1 < \cdots < i_r \leq n} \P(E_{i_1} \and \cdots \and E_{i_r})
 \end{gather}
 $$


### PR DESCRIPTION
The original formula for the inclusion-exclusion principle with n events has 'r-1' in the lower limit of the sum. However, 'r=1' makes much more sense here.