### PR TITLE
Fix typo in Part 1, Definition of Probability

### DIFF
--- a/chapters/part1/probability/index.html
+++ b/chapters/part1/probability/index.html
@@ -100,7 +100,7 @@ of probability, as your number of simulations approaches infinity, the estimate 
 <p><b><i>Problem:</i></b> Use the definition of probability to approximate the answer to the question: "What is the probability a new-born elephant child is male?" Contrary to what you might think the gender outcomes of a newborn elephant are not equally likely between male and female. You have data from a report in Animal Reproductive Science which states that 3,070 elephants were born in Myanmar of which 2,180 were male [<a href="https://www.sciencedirect.com/science/article/pii/S0378432008004442?casa_token=ZTNldN7tjWQAAAAA:4lqVmht0l5ZWe0IsmUFei9VnYrtMAdQ9v4SAEkNCdOh6BBgFFesmlF6YQytPwVNrfrrPxNjbRoE">1</a>]. Humans also don't have a 50/50 sex ratio at birth [<a href="https://www.aihw.gov.au/getmedia/2a0c22a2-ba27-4ba0-ad47-ebbe51854cd6/aihw-per-100-in-brief.pdf.aspx">2</a>].</p>
 
 <p><b><i>Answer:</i></b>
-	The Experiment is: A single elephant birth in Myanmar. <br/>The sample space is the set of possible sexes assigned at birth, {Male, Female, Intersex}. <br/>$E$ is the event that a new-born elephan child is male, which in set notation is the subset {Male} of the sample space. The outcomes are not equally likely.</p>  
+	The Experiment is: A single elephant birth in Myanmar. <br/>The sample space is the set of possible sexes assigned at birth, {Male, Female, Intersex}. <br/>$E$ is the event that a new-born elephant child is male, which in set notation is the subset {Male} of the sample space. The outcomes are not equally likely.</p>
 
 	<p> By the definition of probability, the ratio &mdash; of trials that result in the event, to the total number of trials &mdash; will tend to our desired probability:</p>
 


### PR DESCRIPTION
Fixes a typo in the elephants example in the Part1: Definition of Probability chapter.

elephan -> elephant

