### PR TITLE
Fixed Typos in Set Diversity (Gini Impurity)

### DIFF
--- a/chapters/examples/diversity_shapes/index.html
+++ b/chapters/examples/diversity_shapes/index.html
@@ -33,7 +33,7 @@ a) Consider the following set of shapes. If you chose two shapes <b>with replace
     <p>Define the Sample Space to be the 49 different outcomes of chosing the two shapes with replacement (7 choices for the first shape and 7 choices for the second shape). Notice that in our construction of the sample space we have chosen for the shapes to be treated as all being distinct from one another. An outcome in $S$ ($\in S$) is thus an ordered tuple of distinct shapes. For example one outcome in $S$ is (Shape$_4$, Shape$_2$). $|S| = 7 \times 7 = 49$. Note that all the outcomes in $S$ are equally likely (that was the reason why we treated shapes as distinct).
     </p>
 
-    <p>Let $E$ be the subset of $S$ where the two shapes match. Let $A$ be the event that you have two squares and let $B$ be the event that you have two trianges. Note that $A$ and $B$ are mutually exclusive. By the step rule of counting $|A| = 6 \cdot 6 = 36$ since there are two steps to creating an outcome in $A$: chose a square then chose another square. Similarly $|B| = 1 \cdot 1 = 1$. </p>
+    <p>Let $E$ be the subset of $S$ where the two shapes match. Let $A$ be the event that you have two squares and let $B$ be the event that you have two triangles. Note that $A$ and $B$ are mutually exclusive. By the step rule of counting $|A| = 6 \cdot 6 = 36$ since there are two steps to creating an outcome in $A$: chose a square then chose another square. Similarly $|B| = 1 \cdot 1 = 1$. </p>
 
     $$
     \begin{align*}
@@ -66,7 +66,7 @@ a) Consider the following set of shapes. If you chose two shapes <b>with replace
     
         <p>Let $E$ be the subset of $S$ where the two shapes match.
           <br/>Let $A$ be the event that you have two squares.
-          <br/>Let $B$ be the event that you have two trianges. 
+          <br/>Let $B$ be the event that you have two triangles. 
           <br/>Let $C$ be the event that you have two stars.
           Note that $A$, $B$ and $C$ are mutually exclusive. By the step rule of counting
           <br/> $|A| = 4 \cdot 4 = 16$  
@@ -108,7 +108,7 @@ a) Consider the following set of shapes. If you chose two shapes <b>with replace
 <p>
   <div class="bordered">
     <p>
-First lets generalize our calculation of $G$ for a set of shapes. Let $n$ be the number of shapes in the set. Let $n_i$ be the number of shapes of type $i$ in the set. It is going to be easier to calculate the probability that two share ares are the same than the probability that two shapes are different. If we set up the sample space $S$ to be the set of all ways to pick two shapes (treating each shape as distinct, and treating the selection as ordered). The event space $E$ is then the subset of events where the shapes are the same. Because chosing the same shape of one type is mutually exclusive with chosing the same shape of another type, we can calculate the probability that two shapes are the same by calculating the probability that two shapes are the same for each type of shape and summing them up:
+First lets generalize our calculation of $G$ for a set of shapes. Let $n$ be the number of shapes in the set. Let $n_i$ be the number of shapes of type $i$ in the set. It is going to be easier to calculate the probability that two shapes are the same than the probability that two shapes are different. If we set up the sample space $S$ to be the set of all ways to pick two shapes (treating each shape as distinct, and treating the selection as ordered). The event space $E$ is then the subset of events where the shapes are the same. Because chosing the same shape of one type is mutually exclusive with chosing the same shape of another type, we can calculate the probability that two shapes are the same by calculating the probability that two shapes are the same for each type of shape and summing them up:
 
       $$
       \begin{align*}

--- a/en/examples/diversity_shapes/index.html
+++ b/en/examples/diversity_shapes/index.html
@@ -368,7 +368,7 @@ a) Consider the following set of shapes. If you chose two shapes <b>with replace
     <p>Define the Sample Space to be the 49 different outcomes of chosing the two shapes with replacement (7 choices for the first shape and 7 choices for the second shape). Notice that in our construction of the sample space we have chosen for the shapes to be treated as all being distinct from one another. An outcome in $S$ ($\in S$) is thus an ordered tuple of distinct shapes. For example one outcome in $S$ is (Shape$_4$, Shape$_2$). $|S| = 7 \times 7 = 49$. Note that all the outcomes in $S$ are equally likely (that was the reason why we treated shapes as distinct).
     </p>
 
-    <p>Let $E$ be the subset of $S$ where the two shapes match. Let $A$ be the event that you have two squares and let $B$ be the event that you have two trianges. Note that $A$ and $B$ are mutually exclusive. By the step rule of counting $|A| = 6 \cdot 6 = 36$ since there are two steps to creating an outcome in $A$: chose a square then chose another square. Similarly $|B| = 1 \cdot 1 = 1$. </p>
+    <p>Let $E$ be the subset of $S$ where the two shapes match. Let $A$ be the event that you have two squares and let $B$ be the event that you have two triangles. Note that $A$ and $B$ are mutually exclusive. By the step rule of counting $|A| = 6 \cdot 6 = 36$ since there are two steps to creating an outcome in $A$: chose a square then chose another square. Similarly $|B| = 1 \cdot 1 = 1$. </p>
 
     $$
     \begin{align*}
@@ -401,7 +401,7 @@ a) Consider the following set of shapes. If you chose two shapes <b>with replace
     
         <p>Let $E$ be the subset of $S$ where the two shapes match.
           <br/>Let $A$ be the event that you have two squares.
-          <br/>Let $B$ be the event that you have two trianges. 
+          <br/>Let $B$ be the event that you have two triangles. 
           <br/>Let $C$ be the event that you have two stars.
           Note that $A$, $B$ and $C$ are mutually exclusive. By the step rule of counting
           <br/> $|A| = 4 \cdot 4 = 16$  
@@ -443,7 +443,7 @@ a) Consider the following set of shapes. If you chose two shapes <b>with replace
 <p>
   <div class="bordered">
     <p>
-First lets generalize our calculation of $G$ for a set of shapes. Let $n$ be the number of shapes in the set. Let $n_i$ be the number of shapes of type $i$ in the set. It is going to be easier to calculate the probability that two share ares are the same than the probability that two shapes are different. If we set up the sample space $S$ to be the set of all ways to pick two shapes (treating each shape as distinct, and treating the selection as ordered). The event space $E$ is then the subset of events where the shapes are the same. Because chosing the same shape of one type is mutually exclusive with chosing the same shape of another type, we can calculate the probability that two shapes are the same by calculating the probability that two shapes are the same for each type of shape and summing them up:
+First lets generalize our calculation of $G$ for a set of shapes. Let $n$ be the number of shapes in the set. Let $n_i$ be the number of shapes of type $i$ in the set. It is going to be easier to calculate the probability that two shapes are the same than the probability that two shapes are different. If we set up the sample space $S$ to be the set of all ways to pick two shapes (treating each shape as distinct, and treating the selection as ordered). The event space $E$ is then the subset of events where the shapes are the same. Because chosing the same shape of one type is mutually exclusive with chosing the same shape of another type, we can calculate the probability that two shapes are the same by calculating the probability that two shapes are the same for each type of shape and summing them up:
 
       $$
       \begin{align*}


### PR DESCRIPTION
Fixed the following typos
'shares ares' --> 'shapes', 'trianges' --> 'triangles'



#### Before:
<img width="478" height="40" alt="Screenshot 2026-03-20 at 6 37 32 PM" src="https://github.com/user-attachments/assets/13e07da9-e874-4f7f-ad77-20213eceaa95" />
<img width="358" height="89" alt="Screenshot 2026-03-20 at 6 37 57 PM" src="https://github.com/user-attachments/assets/92cbbab0-d7f5-4e20-a546-702e1299715d" />
<img width="264" height="74" alt="Screenshot 2026-03-20 at 6 38 10 PM" src="https://github.com/user-attachments/assets/9df21d54-514e-47a8-a028-2b97d352099a" />

#### After
<img width="229" height="32" alt="Screenshot 2026-03-20 at 6 39 08 PM" src="https://github.com/user-attachments/assets/e0db3d11-3f86-40d8-8b8a-343b028d4344" />
<img width="352" height="43" alt="Screenshot 2026-03-20 at 6 38 35 PM" src="https://github.com/user-attachments/assets/1d98e351-e7ed-4921-8294-672ee6761191" />
<img width="282" height="40" alt="Screenshot 2026-03-20 at 6 38 57 PM" src="https://github.com/user-attachments/assets/c3f6fe06-a72e-4e46-bd5a-136450f89ab7" />

